### PR TITLE
Fix: Remove modification of x in getDistances

### DIFF
--- a/Common.py
+++ b/Common.py
@@ -147,8 +147,7 @@ def getDistances(x, attr, var, cidx, didx, cheader):
         return np.add(d_dist, c_dist) / numattr
 
     else: #(dtype == 'continuous'):
-        x = pre_normalize(x)
-        return squareform(pdist(x,metric='cityblock'))
+        return squareform(pdist(pre_normalize(x),metric='cityblock'))
 
 ###############################################################################
 # return mask for discrete(0)/continuous(1) attributes and their indices


### PR DESCRIPTION
x = pre_normalize(x)
changes the original data matrix when getDistances is called. This results in slightly incorrect attribute scores at the end.